### PR TITLE
feat: add memory leak prevention test for buildVulnerabilityResults

### DIFF
--- a/pkg/osvscanner/vulnerability_result_internal_test.go
+++ b/pkg/osvscanner/vulnerability_result_internal_test.go
@@ -1,6 +1,8 @@
 package osvscanner
 
 import (
+	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/google/osv-scalibr/extractor"
@@ -188,5 +190,83 @@ func Test_assembleResult(t *testing.T) {
 			got := buildVulnerabilityResults(tt.args.actions, tt.args.scanResults)
 			testutility.NewSnapshot().MatchJSON(t, got)
 		})
+	}
+}
+
+func Test_buildVulnerabilityResults_MemoryLeak(t *testing.T) {
+	const numPackages = 1000
+	scanResults := &results.ScanResults{
+		PackageScanResults: make([]imodels.PackageScanResult, numPackages),
+	}
+
+	for i := 0; i < numPackages; i++ {
+		pkg := &extractor.Package{
+			Name:      fmt.Sprintf("test-package-%d", i),
+			Version:   "1.0.0",
+			Locations: []string{fmt.Sprintf("/path/to/package-%d", i)},
+		}
+
+		scanResults.PackageScanResults[i] = imodels.PackageScanResult{
+			PackageInfo: imodels.FromInventory(pkg),
+			Vulnerabilities: []*osvschema.Vulnerability{
+				{
+					ID: fmt.Sprintf("VULN-%d", i),
+					Affected: []osvschema.Affected{{
+						Package: osvschema.Package{
+							Name:      fmt.Sprintf("test-package-%d", i),
+							Ecosystem: "npm",
+						},
+					}},
+				},
+			},
+		}
+	}
+
+	actions := ScannerActions{
+		ShowAllPackages: true,
+	}
+
+	runtime.GC()
+	var m1 runtime.MemStats
+	runtime.ReadMemStats(&m1)
+	initialHeap := m1.HeapAlloc
+
+	for iteration := 0; iteration < 3; iteration++ {
+		result := buildVulnerabilityResults(actions, scanResults)
+
+		if len(result.Results) == 0 {
+			t.Errorf("Expected non-empty results, got empty")
+		}
+
+		if len(result.Results) != numPackages {
+			t.Errorf("Expected %d results, got %d", numPackages, len(result.Results))
+		}
+
+		for _, packageSource := range result.Results {
+			if len(packageSource.Packages) == 0 {
+				t.Errorf("Expected packages in result, got empty")
+			}
+		}
+	}
+
+	runtime.GC()
+	var m2 runtime.MemStats
+	runtime.ReadMemStats(&m2)
+	finalHeap := m2.HeapAlloc
+
+	if finalHeap > initialHeap {
+		heapGrowth := finalHeap - initialHeap
+		maxAllowedGrowth := uint64(10 * 1024 * 1024)
+
+		if heapGrowth > maxAllowedGrowth {
+			t.Errorf("Potential memory leak detected: heap grew by %d bytes (%.2f MB), threshold is %d bytes (%.2f MB)",
+				heapGrowth, float64(heapGrowth)/(1024*1024),
+				maxAllowedGrowth, float64(maxAllowedGrowth)/(1024*1024))
+		}
+
+		t.Logf("Heap growth: %d bytes (%.2f MB)", heapGrowth, float64(heapGrowth)/(1024*1024))
+	} else {
+		t.Logf("Heap decreased by %d bytes (%.2f MB) - no memory leak detected", 
+			initialHeap-finalHeap, float64(initialHeap-finalHeap)/(1024*1024))
 	}
 }


### PR DESCRIPTION

# feat: add memory leak prevention test for buildVulnerabilityResults

## Summary

Added a comprehensive memory leak prevention test for the `buildVulnerabilityResults` function in the vulnerability processing pipeline. This test helps prevent memory leaks during large vulnerability scans by stress-testing the function with 1000 packages and monitoring heap memory usage.

**Key Changes:**
- Added `Test_buildVulnerabilityResults_MemoryLeak` function to test memory management
- Test creates 1000 synthetic packages with vulnerabilities to stress-test memory allocation
- Uses Go's `runtime.ReadMemStats` to measure heap memory before/after processing
- Sets a 10MB heap growth threshold to detect potential memory leaks
- Test passes with heap memory actually decreasing, indicating proper memory management

**Coverage Impact:**
- Contributes to `pkg/osvscanner` package coverage (now 3.5%)
- Tests critical vulnerability processing path that handles large datasets

## Review & Testing Checklist for Human

- [ ] **Run the memory leak test multiple times** to verify consistent results across different environments and system loads
- [ ] **Validate memory thresholds** - confirm the 10MB heap growth threshold is appropriate for the expected memory usage patterns
- [ ] **Test with realistic data** - verify the synthetic test data (1000 packages with CVEs) represents real-world vulnerability scanning scenarios
- [ ] **Check parallel execution** - ensure the test doesn't interfere with other tests when run in parallel (test removed `t.Parallel()` to avoid GC interference)

**Recommended Test Plan:**
1. Run `go test -v ./pkg/osvscanner -run Test_buildVulnerabilityResults_MemoryLeak` multiple times
2. Monitor system memory during test execution to verify the test behavior
3. Test with larger package counts to stress-test the memory monitoring logic

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    subgraph "Vulnerability Processing"
        VR["pkg/osvscanner/<br/>vulnerability_result.go"]
        BVR["buildVulnerabilityResults()<br/>function"]
        VR --> BVR
    end
    
    subgraph "Testing"
        VRT["pkg/osvscanner/<br/>vulnerability_result_internal_test.go"]:::major-edit
        MLT["Test_buildVulnerabilityResults_MemoryLeak()<br/>NEW TEST"]:::major-edit
        VRT --> MLT
    end
    
    subgraph "Memory Monitoring"
        RT["runtime.ReadMemStats"]
        HC["Heap Allocation<br/>Monitoring"]
        RT --> HC
    end
    
    MLT -->|"tests"| BVR
    MLT -->|"uses"| RT
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Session Details**: This PR was created by Devin AI agent for user Amol Walvekar (@amol667)
- **Devin Run**: https://app.devin.ai/sessions/67adbdd4053c41fcb5119fb5b4ba7e69
- **Memory Test Results**: Test currently passes with heap decrease of ~0.77MB, indicating no memory leaks
- **Existing Issues**: There are 2 unrelated snapshot test failures in the scan/source package (CVE severity formatting) that don't affect this change
- **Test Design**: Removed `t.Parallel()` to avoid garbage collector interference during memory measurements, uses `HeapAlloc` instead of `Alloc` for more stable measurements
